### PR TITLE
Add a issue documentation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,0 +1,43 @@
+---
+name: Documentation Issue
+about: Use this template for documentation related issues
+labels: 'type:docs'
+
+---
+
+Thank you for submitting a Medkit documentation issue ! 
+The medkit docs are under contruction ! To get involved, read the documentation
+contibutor guide:  *https://medkit/contribute/docs*
+
+## **URL(s) with the issue:**
+
+Please provide a link to the documentation entry
+
+## Description of issue (what needs changing):
+
+### **Clear description**
+
+<em>Why should someone use this method? How is it useful?</em>
+
+### **Which items are related to the issue?:**
+
+- [ ] Correct links: 
+
+Is the link to the source code correct?
+
+- [ ] Parameters: 
+
+Are all parameters defined and formatted correctly?
+
+- [ ] Returns defined: 
+
+Are return values defined?
+
+- [ ] Raised listed and defined
+
+Are the errors defined? 
+
+### Submit a pull request?
+
+Are you planning to also submit a pull request to fix the issue? See the docs contributor guide:
+*https://medkit/contribute/docs* and doc style guide: *https://medkit/documentation-style-guide*


### PR DESCRIPTION
This template is related to #1 
I took the Tensorflow documentation template as a reference. 

We could add the contributing file as a link in this document.
