### PR TITLE
FIX: Set default value of optional MedkitKeyword fields to None

### DIFF
--- a/medkit/text/ner/iamsystem_matcher.py
+++ b/medkit/text/ner/iamsystem_matcher.py
@@ -36,9 +36,9 @@ class MedkitKeyword:
     def __init__(
         self,
         label: str,  # String to search in text
-        kb_id: Optional[Any],
-        kb_name: Optional[str],
-        ent_label: Optional[str],  # Output label for the detected entity
+        kb_id: Optional[Any] = None,
+        kb_name: Optional[str] = None,
+        ent_label: Optional[str] = None,  # Output label for the detected entity
     ):
         self.label = label
         self.kb_id = kb_id


### PR DESCRIPTION
To prevent positional argument errors in case no value is provided for these fields to the constructor.